### PR TITLE
PLATTFORM-3158 Oppdater GitHub workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,29 +1,39 @@
 name: Package and Publish image, Create PR for k8s-applications
+
 on:
   # Triggers when new release is published.
   release:
     types: [ published ]
+
+permissions:
+  contents: read
+  packages: write
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: latest=auto
@@ -35,7 +45,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Hva er gjort

- Oppdatert release-workflowen til nyere GitHub Actions major-versjoner:
  - `actions/checkout@v6`
  - `docker/login-action@v4`
  - `docker/metadata-action@v6`
  - `docker/build-push-action@v7`
- Lagt til `docker/setup-buildx-action@v4` før Docker build/push.
- Lagt til eksplisitte workflow-permissions:
  - `contents: read`
  - `packages: write`
- Beholdt eksisterende release-trigger og GHCR image-tagging/push-oppsett.

## Hvorfor

Workflowen brukte utdaterte action-versjoner og hadde ikke eksplisitte rettigheter for publisering til GitHub Container Registry. Oppdateringen reduserer vedlikeholdsgjeld og gjør publish-rettighetene tydelige.

## Validering

- Verifisert tilgjengelige action-tags direkte mot GitHub-repoene med `git ls-remote --tags`.
- Validert YAML-syntaks med Ruby/Psych: `YAML.load_file('.github/workflows/release.yaml')`.

Selve workflowen kjøres først ved publisert GitHub release.